### PR TITLE
Add Adventure Support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -151,7 +151,7 @@
         <dependency>
             <groupId>com.destroystokyo.paper</groupId>
             <artifactId>paper-api</artifactId>
-            <version>1.16.4-R0.1-SNAPSHOT</version>
+            <version>1.16.5-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <!-- NMS -->

--- a/src/main/java/me/pugabyte/nexus/features/chat/Chat.java
+++ b/src/main/java/me/pugabyte/nexus/features/chat/Chat.java
@@ -15,10 +15,16 @@ import me.pugabyte.nexus.models.nerd.Rank;
 import me.pugabyte.nexus.utils.JsonBuilder;
 import me.pugabyte.nexus.utils.StringUtils;
 import me.pugabyte.nexus.utils.Time.Timer;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.TranslatableComponent;
+import net.kyori.adventure.text.format.Style;
 import net.md_5.bungee.api.ChatColor;
 import org.bukkit.Bukkit;
 
+import java.util.Collection;
 import java.util.HashMap;
+import java.util.List;
+import java.util.stream.Collectors;
 
 public class Chat extends Feature {
 
@@ -195,6 +201,34 @@ public class Chat extends Feature {
 		channel.broadcast(message, muteMenuItem);
 	}
 
+	public static void broadcast(Component message) {
+		broadcast(message, ChatManager.getMainChannel());
+	}
+
+	public static void broadcast(Component message, MuteMenuItem muteMenuItem) {
+		broadcast(message, ChatManager.getMainChannel(), muteMenuItem);
+	}
+
+	public static void broadcast(Component message, StaticChannel channel) {
+		broadcast(message, ChatManager.getChannel(channel.name()));
+	}
+
+	public static void broadcast(Component message, StaticChannel channel, MuteMenuItem muteMenuItem) {
+		broadcast(message, ChatManager.getChannel(channel.name()), muteMenuItem);
+	}
+
+	public static void broadcast(Component message, String channel) {
+		broadcast(message, ChatManager.getChannel(channel));
+	}
+
+	public static void broadcast(Component message, PublicChannel channel) {
+		broadcast(message, channel, null);
+	}
+
+	public static void broadcast(Component message, PublicChannel channel, MuteMenuItem muteMenuItem) {
+		channel.broadcast(message, muteMenuItem);
+	}
+
 	public static void broadcastIngame(String message) {
 		broadcastIngame(message, ChatManager.getMainChannel());
 	}
@@ -251,6 +285,34 @@ public class Chat extends Feature {
 		channel.broadcastIngame(message, muteMenuItem);
 	}
 
+	public static void broadcastIngame(Component message) {
+		broadcastIngame(message, ChatManager.getMainChannel());
+	}
+
+	public static void broadcastIngame(Component message, MuteMenuItem muteMenuItem) {
+		broadcastIngame(message, ChatManager.getMainChannel(), muteMenuItem);
+	}
+
+	public static void broadcastIngame(Component message, StaticChannel channel) {
+		broadcastIngame(message, ChatManager.getChannel(channel.name()));
+	}
+
+	public static void broadcastIngame(Component message, StaticChannel channel, MuteMenuItem muteMenuItem) {
+		broadcastIngame(message, ChatManager.getChannel(channel.name()), muteMenuItem);
+	}
+
+	public static void broadcastIngame(Component message, String channel) {
+		broadcastIngame(message, ChatManager.getChannel(channel));
+	}
+
+	public static void broadcastIngame(Component message, PublicChannel channel) {
+		broadcastIngame(message, channel, null);
+	}
+
+	public static void broadcastIngame(Component message, PublicChannel channel, MuteMenuItem muteMenuItem) {
+		channel.broadcastIngame(message, muteMenuItem);
+	}
+
 	public static void broadcastDiscord(String message) {
 		broadcastDiscord(message, ChatManager.getMainChannel());
 	}
@@ -281,6 +343,35 @@ public class Chat extends Feature {
 
 	public static void broadcastDiscord(JsonBuilder message, PublicChannel channel) {
 		channel.broadcastDiscord(message);
+	}
+
+	public static void broadcastDiscord(Component message) {
+		broadcastDiscord(message, ChatManager.getMainChannel());
+	}
+
+	public static void broadcastDiscord(Component message, StaticChannel channel) {
+		broadcastDiscord(message, ChatManager.getChannel(channel.name()));
+	}
+
+	public static void broadcastDiscord(Component message, String channel) {
+		broadcastDiscord(message, ChatManager.getChannel(channel));
+	}
+
+	public static void broadcastDiscord(Component message, PublicChannel channel) {
+		channel.broadcastDiscord(message);
+	}
+
+	public static Component stripColor(Component component) {
+		component = component.style(Style.empty());
+		if (component instanceof TranslatableComponent) {
+			TranslatableComponent tComponent = (TranslatableComponent) component;
+			component = tComponent.args(stripColor(tComponent.args()));
+		}
+		return component.children(stripColor(component.children()));
+	}
+
+	public static List<Component> stripColor(Collection<Component> components) {
+		return components.stream().map(Chat::stripColor).collect(Collectors.toList());
 	}
 
 }

--- a/src/main/java/me/pugabyte/nexus/features/chat/Chat.java
+++ b/src/main/java/me/pugabyte/nexus/features/chat/Chat.java
@@ -12,19 +12,19 @@ import me.pugabyte.nexus.models.chat.ChatService;
 import me.pugabyte.nexus.models.chat.Chatter;
 import me.pugabyte.nexus.models.chat.PublicChannel;
 import me.pugabyte.nexus.models.nerd.Rank;
+import me.pugabyte.nexus.utils.AdventureUtils;
 import me.pugabyte.nexus.utils.JsonBuilder;
 import me.pugabyte.nexus.utils.StringUtils;
 import me.pugabyte.nexus.utils.Time.Timer;
+import net.kyori.adventure.audience.MessageType;
+import net.kyori.adventure.identity.Identified;
+import net.kyori.adventure.identity.Identity;
 import net.kyori.adventure.text.Component;
-import net.kyori.adventure.text.TranslatableComponent;
-import net.kyori.adventure.text.format.Style;
 import net.md_5.bungee.api.ChatColor;
 import org.bukkit.Bukkit;
 
-import java.util.Collection;
 import java.util.HashMap;
-import java.util.List;
-import java.util.stream.Collectors;
+import java.util.UUID;
 
 public class Chat extends Feature {
 
@@ -205,8 +205,60 @@ public class Chat extends Feature {
 		broadcast(message, ChatManager.getMainChannel());
 	}
 
+	public static void broadcast(Component message, MessageType type) {
+		broadcast(message, ChatManager.getMainChannel(), type);
+	}
+
 	public static void broadcast(Component message, MuteMenuItem muteMenuItem) {
 		broadcast(message, ChatManager.getMainChannel(), muteMenuItem);
+	}
+
+	public static void broadcast(Identity sender, Component message) {
+		broadcast(sender, message, ChatManager.getMainChannel());
+	}
+
+	public static void broadcast(Identified sender, Component message) {
+		broadcast(sender, message, ChatManager.getMainChannel());
+	}
+
+	public static void broadcast(UUID sender, Component message) {
+		broadcast(sender, message, ChatManager.getMainChannel());
+	}
+
+	public static void broadcast(Identity sender, Component message, MuteMenuItem muteMenuItem) {
+		broadcast(sender, message, ChatManager.getMainChannel(), muteMenuItem);
+	}
+
+	public static void broadcast(Identified sender, Component message, MuteMenuItem muteMenuItem) {
+		broadcast(sender, message, ChatManager.getMainChannel(), muteMenuItem);
+	}
+
+	public static void broadcast(UUID sender, Component message, MuteMenuItem muteMenuItem) {
+		broadcast(sender, message, ChatManager.getMainChannel(), muteMenuItem);
+	}
+
+	public static void broadcast(Identity sender, Component message, MessageType type) {
+		broadcast(sender, message, ChatManager.getMainChannel(), type);
+	}
+
+	public static void broadcast(Identified sender, Component message, MessageType type) {
+		broadcast(sender, message, ChatManager.getMainChannel(), type);
+	}
+
+	public static void broadcast(UUID sender, Component message, MessageType type) {
+		broadcast(sender, message, ChatManager.getMainChannel(), type);
+	}
+
+	public static void broadcast(Identity sender, Component message, MessageType type, MuteMenuItem muteMenuItem) {
+		broadcast(sender, message, ChatManager.getMainChannel(), type, muteMenuItem);
+	}
+
+	public static void broadcast(Identified sender, Component message, MessageType type, MuteMenuItem muteMenuItem) {
+		broadcast(sender, message, ChatManager.getMainChannel(), type, muteMenuItem);
+	}
+
+	public static void broadcast(UUID sender, Component message, MessageType type, MuteMenuItem muteMenuItem) {
+		broadcast(sender, message, ChatManager.getMainChannel(), type, muteMenuItem);
 	}
 
 	public static void broadcast(Component message, StaticChannel channel) {
@@ -217,16 +269,188 @@ public class Chat extends Feature {
 		broadcast(message, ChatManager.getChannel(channel.name()), muteMenuItem);
 	}
 
+	public static void broadcast(Component message, StaticChannel channel, MessageType type, MuteMenuItem muteMenuItem) {
+		broadcast(Identity.nil(), message, channel, type, muteMenuItem);
+	}
+
+	public static void broadcast(Identity sender, Component message, StaticChannel channel, MuteMenuItem muteMenuItem) {
+		broadcast(sender, message, channel, MessageType.SYSTEM, muteMenuItem);
+	}
+
+	public static void broadcast(Identified sender, Component message, StaticChannel channel, MuteMenuItem muteMenuItem) {
+		broadcast(sender, message, channel, MessageType.SYSTEM, muteMenuItem);
+	}
+
+	public static void broadcast(UUID sender, Component message, StaticChannel channel, MuteMenuItem muteMenuItem) {
+		broadcast(sender, message, channel, MessageType.SYSTEM, muteMenuItem);
+	}
+
+	public static void broadcast(Component message, StaticChannel channel, MessageType type) {
+		broadcast(Identity.nil(), message, channel, type);
+	}
+
+	public static void broadcast(Identity sender, Component message, StaticChannel channel) {
+		broadcast(sender, message, channel, MessageType.SYSTEM, null);
+	}
+
+	public static void broadcast(Identified sender, Component message, StaticChannel channel) {
+		broadcast(sender, message, channel, MessageType.SYSTEM, null);
+	}
+
+	public static void broadcast(UUID sender, Component message, StaticChannel channel) {
+		broadcast(sender, message, channel, MessageType.SYSTEM, null);
+	}
+
+	public static void broadcast(Identity sender, Component message, StaticChannel channel, MessageType type) {
+		broadcast(sender, message, channel, type, null);
+	}
+
+	public static void broadcast(Identified sender, Component message, StaticChannel channel, MessageType type) {
+		broadcast(sender, message, channel, type, null);
+	}
+
+	public static void broadcast(UUID sender, Component message, StaticChannel channel, MessageType type) {
+		broadcast(sender, message, channel, type, null);
+	}
+
+	public static void broadcast(Identity sender, Component message, StaticChannel channel, MessageType type, MuteMenuItem muteMenuItem) {
+		broadcast(sender, message, ChatManager.getChannel(channel.name()), type, muteMenuItem);
+	}
+
+	public static void broadcast(Identified sender, Component message, StaticChannel channel, MessageType type, MuteMenuItem muteMenuItem) {
+		broadcast(sender.identity(), message, channel, type, muteMenuItem);
+	}
+
+	public static void broadcast(UUID sender, Component message, StaticChannel channel, MessageType type, MuteMenuItem muteMenuItem) {
+		broadcast(AdventureUtils.identityOf(sender), message, channel, type, muteMenuItem);
+	}
+
 	public static void broadcast(Component message, String channel) {
-		broadcast(message, ChatManager.getChannel(channel));
+		broadcast(message, channel, MessageType.SYSTEM);
+	}
+
+	public static void broadcast(Identity sender, Component message, String channel) {
+		broadcast(sender, message, channel, MessageType.SYSTEM);
+	}
+
+	public static void broadcast(Identified sender, Component message, String channel) {
+		broadcast(sender, message, channel, MessageType.SYSTEM);
+	}
+
+	public static void broadcast(UUID sender, Component message, String channel) {
+		broadcast(sender, message, channel, MessageType.SYSTEM);
+	}
+
+	public static void broadcast(Component message, String channel, MessageType type, MuteMenuItem muteMenuItem) {
+		broadcast(Identity.nil(), message, channel, type, muteMenuItem);
+	}
+
+	public static void broadcast(Component message, String channel, MuteMenuItem muteMenuItem) {
+		broadcast(Identity.nil(), message, channel, MessageType.SYSTEM, muteMenuItem);
+	}
+
+	public static void broadcast(Identity sender, Component message, String channel, MuteMenuItem muteMenuItem) {
+		broadcast(sender, message, channel, MessageType.SYSTEM, muteMenuItem);
+	}
+
+	public static void broadcast(Identified sender, Component message, String channel, MuteMenuItem muteMenuItem) {
+		broadcast(sender, message, channel, MessageType.SYSTEM, muteMenuItem);
+	}
+
+	public static void broadcast(UUID sender, Component message, String channel, MuteMenuItem muteMenuItem) {
+		broadcast(sender, message, channel, MessageType.SYSTEM, muteMenuItem);
+	}
+
+	public static void broadcast(Component message, String channel, MessageType type) {
+		broadcast(Identity.nil(), message, channel, type);
+	}
+
+	public static void broadcast(Identity sender, Component message, String channel, MessageType type) {
+		broadcast(sender, message, channel, type, null);
+	}
+
+	public static void broadcast(Identified sender, Component message, String channel, MessageType type) {
+		broadcast(sender, message, channel, type, null);
+	}
+
+	public static void broadcast(UUID sender, Component message, String channel, MessageType type) {
+		broadcast(sender, message, channel, type, null);
+	}
+
+	public static void broadcast(Identity sender, Component message, String channel, MessageType type, MuteMenuItem muteMenuItem) {
+		broadcast(sender, message, ChatManager.getChannel(channel), type, muteMenuItem);
+	}
+
+	public static void broadcast(Identified sender, Component message, String channel, MessageType type, MuteMenuItem muteMenuItem) {
+		broadcast(sender.identity(), message, channel, type, muteMenuItem);
+	}
+
+	public static void broadcast(UUID sender, Component message, String channel, MessageType type, MuteMenuItem muteMenuItem) {
+		broadcast(AdventureUtils.identityOf(sender), message, channel, type, muteMenuItem);
 	}
 
 	public static void broadcast(Component message, PublicChannel channel) {
-		broadcast(message, channel, null);
+		broadcast(message, channel, MessageType.SYSTEM, null);
+	}
+
+	public static void broadcast(Identity sender, Component message, PublicChannel channel) {
+		broadcast(sender, message, channel, MessageType.SYSTEM);
+	}
+
+	public static void broadcast(Identified sender, Component message, PublicChannel channel) {
+		broadcast(sender, message, channel, MessageType.SYSTEM);
+	}
+
+	public static void broadcast(UUID sender, Component message, PublicChannel channel) {
+		broadcast(sender, message, channel, MessageType.SYSTEM);
+	}
+
+	public static void broadcast(Component message, PublicChannel channel, MessageType type, MuteMenuItem muteMenuItem) {
+		broadcast(Identity.nil(), message, channel, type, muteMenuItem);
 	}
 
 	public static void broadcast(Component message, PublicChannel channel, MuteMenuItem muteMenuItem) {
-		channel.broadcast(message, muteMenuItem);
+		broadcast(Identity.nil(), message, channel, MessageType.SYSTEM, muteMenuItem);
+	}
+
+	public static void broadcast(Identity sender, Component message, PublicChannel channel, MuteMenuItem muteMenuItem) {
+		broadcast(sender, message, channel, MessageType.SYSTEM, muteMenuItem);
+	}
+
+	public static void broadcast(Identified sender, Component message, PublicChannel channel, MuteMenuItem muteMenuItem) {
+		broadcast(sender, message, channel, MessageType.SYSTEM, muteMenuItem);
+	}
+
+	public static void broadcast(UUID sender, Component message, PublicChannel channel, MuteMenuItem muteMenuItem) {
+		broadcast(sender, message, channel, MessageType.SYSTEM, muteMenuItem);
+	}
+
+	public static void broadcast(Component message, PublicChannel channel, MessageType type) {
+		broadcast(Identity.nil(), message, channel, type);
+	}
+
+	public static void broadcast(Identity sender, Component message, PublicChannel channel, MessageType type) {
+		broadcast(sender, message, channel, type, null);
+	}
+
+	public static void broadcast(Identified sender, Component message, PublicChannel channel, MessageType type) {
+		broadcast(sender, message, channel, type, null);
+	}
+
+	public static void broadcast(UUID sender, Component message, PublicChannel channel, MessageType type) {
+		broadcast(sender, message, channel, type, null);
+	}
+
+	public static void broadcast(Identity sender, Component message, PublicChannel channel, MessageType type, MuteMenuItem muteMenuItem) {
+		channel.broadcast(sender, message, type, muteMenuItem);
+	}
+
+	public static void broadcast(Identified sender, Component message, PublicChannel channel, MessageType type, MuteMenuItem muteMenuItem) {
+		broadcast(sender.identity(), message, channel, type, muteMenuItem);
+	}
+
+	public static void broadcast(UUID sender, Component message, PublicChannel channel, MessageType type, MuteMenuItem muteMenuItem) {
+		broadcast(AdventureUtils.identityOf(sender), message, channel, type, muteMenuItem);
 	}
 
 	public static void broadcastIngame(String message) {
@@ -289,8 +513,48 @@ public class Chat extends Feature {
 		broadcastIngame(message, ChatManager.getMainChannel());
 	}
 
+	public static void broadcastIngame(Identity sender, Component message) {
+		broadcastIngame(sender, message, ChatManager.getMainChannel());
+	}
+
+	public static void broadcastIngame(Identified sender, Component message) {
+		broadcastIngame(sender, message, ChatManager.getMainChannel());
+	}
+
+	public static void broadcastIngame(UUID sender, Component message) {
+		broadcastIngame(sender, message, ChatManager.getMainChannel());
+	}
+
 	public static void broadcastIngame(Component message, MuteMenuItem muteMenuItem) {
 		broadcastIngame(message, ChatManager.getMainChannel(), muteMenuItem);
+	}
+
+	public static void broadcastIngame(Identity sender, Component message, MuteMenuItem muteMenuItem) {
+		broadcastIngame(sender, message, ChatManager.getMainChannel(), muteMenuItem);
+	}
+
+	public static void broadcastIngame(Identified sender, Component message, MuteMenuItem muteMenuItem) {
+		broadcastIngame(sender, message, ChatManager.getMainChannel(), muteMenuItem);
+	}
+
+	public static void broadcastIngame(UUID sender, Component message, MuteMenuItem muteMenuItem) {
+		broadcastIngame(sender, message, ChatManager.getMainChannel(), muteMenuItem);
+	}
+
+	public static void broadcastIngame(Component message, MessageType type) {
+		broadcastIngame(message, ChatManager.getMainChannel(), type);
+	}
+
+	public static void broadcastIngame(Identity sender, Component message, MessageType type) {
+		broadcastIngame(sender, message, ChatManager.getMainChannel(), type);
+	}
+
+	public static void broadcastIngame(Identified sender, Component message, MessageType type) {
+		broadcastIngame(sender, message, ChatManager.getMainChannel(), type);
+	}
+
+	public static void broadcastIngame(UUID sender, Component message, MessageType type) {
+		broadcastIngame(sender, message, ChatManager.getMainChannel(), type);
 	}
 
 	public static void broadcastIngame(Component message, StaticChannel channel) {
@@ -305,12 +569,120 @@ public class Chat extends Feature {
 		broadcastIngame(message, ChatManager.getChannel(channel));
 	}
 
+	public static void broadcastIngame(Component message, String channel, MuteMenuItem muteMenuItem) {
+		broadcastIngame(Identity.nil(), message, channel, muteMenuItem);
+	}
+
+	public static void broadcastIngame(Identity sender, Component message, String channel) {
+		broadcastIngame(sender, message, channel, MessageType.SYSTEM);
+	}
+
+	public static void broadcastIngame(Identified sender, Component message, String channel) {
+		broadcastIngame(sender, message, channel, MessageType.SYSTEM);
+	}
+
+	public static void broadcastIngame(UUID sender, Component message, String channel) {
+		broadcastIngame(sender, message, channel, MessageType.SYSTEM);
+	}
+
+	public static void broadcastIngame(Identity sender, Component message, String channel, MuteMenuItem muteMenuItem) {
+		broadcastIngame(sender, message, channel, MessageType.SYSTEM, muteMenuItem);
+	}
+
+	public static void broadcastIngame(Identified sender, Component message, String channel, MuteMenuItem muteMenuItem) {
+		broadcastIngame(sender, message, channel, MessageType.SYSTEM, muteMenuItem);
+	}
+
+	public static void broadcastIngame(UUID sender, Component message, String channel, MuteMenuItem muteMenuItem) {
+		broadcastIngame(sender, message, channel, MessageType.SYSTEM, muteMenuItem);
+	}
+
+	public static void broadcastIngame(Component message, String channel, MessageType type) {
+		broadcastIngame(Identity.nil(), message, channel, type);
+	}
+
+	public static void broadcastIngame(Identity sender, Component message, String channel, MessageType type) {
+		broadcastIngame(sender, message, channel, type, null);
+	}
+
+	public static void broadcastIngame(Identified sender, Component message, String channel, MessageType type) {
+		broadcastIngame(sender, message, channel, type, null);
+	}
+
+	public static void broadcastIngame(UUID sender, Component message, String channel, MessageType type) {
+		broadcastIngame(sender, message, channel, type, null);
+	}
+
+	public static void broadcastIngame(Identity sender, Component message, String channel, MessageType type, MuteMenuItem muteMenuItem) {
+		broadcastIngame(sender, message, ChatManager.getChannel(channel), type, muteMenuItem);
+	}
+
+	public static void broadcastIngame(Identified sender, Component message, String channel, MessageType type, MuteMenuItem muteMenuItem) {
+		broadcastIngame(sender.identity(), message, channel, type, muteMenuItem);
+	}
+
+	public static void broadcastIngame(UUID sender, Component message, String channel, MessageType type, MuteMenuItem muteMenuItem) {
+		broadcastIngame(AdventureUtils.identityOf(sender), message, channel, type, muteMenuItem);
+	}
+
 	public static void broadcastIngame(Component message, PublicChannel channel) {
-		broadcastIngame(message, channel, null);
+		broadcastIngame(message, channel, MessageType.SYSTEM);
 	}
 
 	public static void broadcastIngame(Component message, PublicChannel channel, MuteMenuItem muteMenuItem) {
-		channel.broadcastIngame(message, muteMenuItem);
+		broadcastIngame(Identity.nil(), message, channel, muteMenuItem);
+	}
+
+	public static void broadcastIngame(Identity sender, Component message, PublicChannel channel) {
+		broadcastIngame(sender, message, channel, MessageType.SYSTEM);
+	}
+
+	public static void broadcastIngame(Identified sender, Component message, PublicChannel channel) {
+		broadcastIngame(sender, message, channel, MessageType.SYSTEM);
+	}
+
+	public static void broadcastIngame(UUID sender, Component message, PublicChannel channel) {
+		broadcastIngame(sender, message, channel, MessageType.SYSTEM);
+	}
+
+	public static void broadcastIngame(Identity sender, Component message, PublicChannel channel, MuteMenuItem muteMenuItem) {
+		broadcastIngame(sender, message, channel, MessageType.SYSTEM, muteMenuItem);
+	}
+
+	public static void broadcastIngame(Identified sender, Component message, PublicChannel channel, MuteMenuItem muteMenuItem) {
+		broadcastIngame(sender, message, channel, MessageType.SYSTEM, muteMenuItem);
+	}
+
+	public static void broadcastIngame(UUID sender, Component message, PublicChannel channel, MuteMenuItem muteMenuItem) {
+		broadcastIngame(sender, message, channel, MessageType.SYSTEM, muteMenuItem);
+	}
+
+	public static void broadcastIngame(Component message, PublicChannel channel, MessageType type) {
+		broadcastIngame(Identity.nil(), message, channel, type);
+	}
+
+	public static void broadcastIngame(Identity sender, Component message, PublicChannel channel, MessageType type) {
+		broadcastIngame(sender, message, channel, type, null);
+	}
+
+	public static void broadcastIngame(Identified sender, Component message, PublicChannel channel, MessageType type) {
+		broadcastIngame(sender, message, channel, type, null);
+	}
+
+	public static void broadcastIngame(UUID sender, Component message, PublicChannel channel, MessageType type) {
+		broadcastIngame(sender, message, channel, type, null);
+	}
+
+	public static void broadcastIngame(Identity sender, Component message, PublicChannel channel, MessageType type, MuteMenuItem muteMenuItem) {
+		channel.broadcastIngame(sender, message, type, muteMenuItem);
+	}
+
+	public static void broadcastIngame(Identified sender, Component message, PublicChannel channel, MessageType type, MuteMenuItem muteMenuItem) {
+		broadcastIngame(sender.identity(), message, channel, type, muteMenuItem);
+	}
+
+	public static void broadcastIngame(UUID sender, Component message, PublicChannel channel, MessageType type, MuteMenuItem muteMenuItem) {
+		broadcastIngame(AdventureUtils.identityOf(sender), message, channel, type, muteMenuItem);
 	}
 
 	public static void broadcastDiscord(String message) {
@@ -359,19 +731,6 @@ public class Chat extends Feature {
 
 	public static void broadcastDiscord(Component message, PublicChannel channel) {
 		channel.broadcastDiscord(message);
-	}
-
-	public static Component stripColor(Component component) {
-		component = component.style(Style.empty());
-		if (component instanceof TranslatableComponent) {
-			TranslatableComponent tComponent = (TranslatableComponent) component;
-			component = tComponent.args(stripColor(tComponent.args()));
-		}
-		return component.children(stripColor(component.children()));
-	}
-
-	public static List<Component> stripColor(Collection<Component> components) {
-		return components.stream().map(Chat::stripColor).collect(Collectors.toList());
 	}
 
 }

--- a/src/main/java/me/pugabyte/nexus/features/chat/ChatManager.java
+++ b/src/main/java/me/pugabyte/nexus/features/chat/ChatManager.java
@@ -13,10 +13,13 @@ import me.pugabyte.nexus.models.chat.PublicChannel;
 import me.pugabyte.nexus.models.cooldown.CooldownService;
 import me.pugabyte.nexus.models.nerd.Nerd;
 import me.pugabyte.nexus.models.nerd.Rank;
+import me.pugabyte.nexus.utils.AdventureUtils;
 import me.pugabyte.nexus.utils.JsonBuilder;
 import me.pugabyte.nexus.utils.PlayerUtils;
 import me.pugabyte.nexus.utils.Tasks;
 import me.pugabyte.nexus.utils.Time;
+import net.kyori.adventure.audience.MessageType;
+import net.kyori.adventure.text.Component;
 import org.bukkit.Bukkit;
 
 import java.util.ArrayList;
@@ -123,11 +126,14 @@ public class ChatManager {
 					.addHover("&cClick to see original message")
 					.command("/echo &3Original message: " + decolorize(chatterFormat + event.getOriginalMessage()));
 
+		Component aPlayer = AdventureUtils.fromJson(json);
+		Component aStaff = AdventureUtils.fromJson(staff);
+
 		event.getRecipients().forEach(recipient -> {
 			if (Rank.of(recipient.getPlayer()).isStaff())
-				recipient.send(staff);
+				recipient.send(nerd, aStaff, MessageType.CHAT);
 			else
-				recipient.send(json);
+				recipient.send(nerd, aPlayer, MessageType.CHAT);
 		});
 
 		Bukkit.getConsoleSender().sendMessage(stripColor(json.toString()));
@@ -140,6 +146,7 @@ public class ChatManager {
 				.next(event.getChannel().getMessageColor() + event.getMessage());
 		JsonBuilder from = new JsonBuilder("&3&l[&bPM&3&l] &eFrom &3" + Nerd.of(event.getChatter().getOfflinePlayer()).getNickname() + " &b&l> ")
 				.next(event.getChannel().getMessageColor() + event.getMessage());
+		Component aFrom = AdventureUtils.fromJson(from);
 
 		int seen = 0;
 		for (Chatter recipient : event.getRecipients()) {
@@ -151,7 +158,7 @@ public class ChatManager {
 				if (!recipient.getOfflinePlayer().isOnline())
 					event.getChatter().send(Chat.PREFIX + notOnline);
 				else {
-					recipient.send(from);
+					recipient.send(event.getChatter(), aFrom, MessageType.CHAT);
 					if (canSee)
 						++seen;
 					else

--- a/src/main/java/me/pugabyte/nexus/features/chat/Koda.java
+++ b/src/main/java/me/pugabyte/nexus/features/chat/Koda.java
@@ -13,6 +13,7 @@ import me.pugabyte.nexus.features.minigames.utils.MinigameNight.NextMGN;
 import me.pugabyte.nexus.models.chat.ChatService;
 import me.pugabyte.nexus.models.chat.Chatter;
 import me.pugabyte.nexus.models.chat.PublicChannel;
+import me.pugabyte.nexus.utils.AdventureUtils;
 import me.pugabyte.nexus.utils.PlayerUtils;
 import me.pugabyte.nexus.utils.RandomUtils;
 import me.pugabyte.nexus.utils.StringUtils;
@@ -65,7 +66,7 @@ public class Koda {
 	}
 
 	public static void sayIngame(String message) {
-		Chat.broadcastIngame(globalFormat + message);
+		Chat.broadcastIngame(AdventureUtils.fromLegacyAmpersandText(globalFormat + message));
 	}
 
 	public static void sayDiscord(String message) {

--- a/src/main/java/me/pugabyte/nexus/features/commands/DeathMessagesCommand.java
+++ b/src/main/java/me/pugabyte/nexus/features/commands/DeathMessagesCommand.java
@@ -1,6 +1,5 @@
 package me.pugabyte.nexus.features.commands;
 
-import com.google.common.base.Strings;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import me.pugabyte.nexus.features.chat.Chat;
@@ -9,19 +8,29 @@ import me.pugabyte.nexus.framework.commands.models.CustomCommand;
 import me.pugabyte.nexus.framework.commands.models.annotations.Arg;
 import me.pugabyte.nexus.framework.commands.models.annotations.Path;
 import me.pugabyte.nexus.framework.commands.models.events.CommandEvent;
+import me.pugabyte.nexus.framework.exceptions.postconfigured.InvalidInputException;
+import me.pugabyte.nexus.framework.exceptions.postconfigured.PlayerNotFoundException;
 import me.pugabyte.nexus.models.chat.ChatService;
 import me.pugabyte.nexus.models.chat.Chatter;
 import me.pugabyte.nexus.models.deathmessages.DeathMessages;
 import me.pugabyte.nexus.models.deathmessages.DeathMessages.Behavior;
 import me.pugabyte.nexus.models.deathmessages.DeathMessagesService;
+import me.pugabyte.nexus.models.nerd.Nerd;
 import me.pugabyte.nexus.utils.WorldGroup;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.TextComponent;
+import net.kyori.adventure.text.TranslatableComponent;
+import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.PlayerDeathEvent;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
 import static me.pugabyte.nexus.features.discord.Discord.discordize;
-import static me.pugabyte.nexus.utils.StringUtils.colorize;
 
 @NoArgsConstructor
 public class DeathMessagesCommand extends CustomCommand implements Listener {
@@ -45,27 +54,48 @@ public class DeathMessagesCommand extends CustomCommand implements Listener {
 		final DeathMessagesService service = new DeathMessagesService();
 		DeathMessages deathMessages = service.get(event.getEntity());
 
-		String message = "&c☠ " + event.getDeathMessage();
-		message = message.replaceFirst(event.getEntity().getName(), "&e" + event.getEntity().getName() + "&c");
-		if (event.getEntity().getKiller() != null)
-			message = message.replaceFirst(event.getEntity().getKiller().getName(), "&e" + event.getEntity().getKiller().getName() + "&c");
+		TranslatableComponent deathMessage = (TranslatableComponent) event.deathMessage();
+		TextComponent output;
+		if (deathMessage == null) {
+			// failsafe? :P
+			output = Component.text("☠ ").color(NamedTextColor.RED)
+					.append(Component.text(deathMessages.getNickname()).color(NamedTextColor.YELLOW))
+					.append(Component.text(" spontaneously ceased existence").color(NamedTextColor.RED));
+		} else {
+			List<Component> args = new ArrayList<>();
+			deathMessage.args().forEach(component -> {
+				if (!(component instanceof TextComponent) || component.children().size() != 1 || !(component.children().get(0) instanceof TextComponent)) {
+					args.add(component);
+					return;
+				}
+				// this (should) have a text component inside with the name of a player so we are going to color it
+				TextComponent textComponent = ((TextComponent) component.children().get(0)).color(NamedTextColor.YELLOW);
+				// and set their name to their nickname
+				if (textComponent.content().equals(deathMessages.getName()))
+					textComponent = textComponent.content(deathMessages.getNickname());
+				else {
+					try {
+						textComponent = textComponent.content(Nerd.of(textComponent.content()).getNickname());
+					}
+					catch (PlayerNotFoundException|InvalidInputException ignored) {}
+				}
+				args.add(component.children(Collections.singletonList(textComponent)));
+			});
+			deathMessage = deathMessage.args(args);
+			output = Component.text("☠ ").color(NamedTextColor.RED).append(deathMessage);
+		}
 
-		if (deathMessages.getBehavior() == Behavior.HIDDEN)
-			event.setDeathMessage(null);
-
-		if (Strings.isNullOrEmpty(event.getDeathMessage())) return;
-
-		event.setDeathMessage(null);
+		event.deathMessage(null);
 
 		if (deathMessages.getBehavior() == Behavior.SHOWN) {
-			Chat.broadcastIngame(colorize(message));
+			Chat.broadcastIngame(output);
 
 			if (WorldGroup.get(event.getEntity()) == WorldGroup.SURVIVAL)
-				Chat.broadcastDiscord(discordize(message));
+				Chat.broadcastDiscord(discordize(output));
 		} else if (deathMessages.getBehavior() == Behavior.LOCAL) {
 			Chatter chatter = new ChatService().get(event.getEntity());
 			for (Chatter recipient : StaticChannel.LOCAL.getChannel().getRecipients(chatter))
-				recipient.send(message);
+				recipient.send(output);
 		}
 	}
 

--- a/src/main/java/me/pugabyte/nexus/features/commands/DeathMessagesCommand.java
+++ b/src/main/java/me/pugabyte/nexus/features/commands/DeathMessagesCommand.java
@@ -17,6 +17,7 @@ import me.pugabyte.nexus.models.deathmessages.DeathMessages.Behavior;
 import me.pugabyte.nexus.models.deathmessages.DeathMessagesService;
 import me.pugabyte.nexus.models.nerd.Nerd;
 import me.pugabyte.nexus.utils.WorldGroup;
+import net.kyori.adventure.audience.MessageType;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.TextComponent;
 import net.kyori.adventure.text.TranslatableComponent;
@@ -88,14 +89,14 @@ public class DeathMessagesCommand extends CustomCommand implements Listener {
 		event.deathMessage(null);
 
 		if (deathMessages.getBehavior() == Behavior.SHOWN) {
-			Chat.broadcastIngame(output);
+			Chat.broadcastIngame(event.getEntity(), output, MessageType.CHAT);
 
 			if (WorldGroup.get(event.getEntity()) == WorldGroup.SURVIVAL)
 				Chat.broadcastDiscord(discordize(output));
 		} else if (deathMessages.getBehavior() == Behavior.LOCAL) {
 			Chatter chatter = new ChatService().get(event.getEntity());
 			for (Chatter recipient : StaticChannel.LOCAL.getChannel().getRecipients(chatter))
-				recipient.send(output);
+				recipient.send(event.getEntity(), output, MessageType.CHAT);
 		}
 	}
 

--- a/src/main/java/me/pugabyte/nexus/features/discord/Discord.java
+++ b/src/main/java/me/pugabyte/nexus/features/discord/Discord.java
@@ -23,6 +23,8 @@ import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.entities.Role;
 import net.dv8tion.jda.api.entities.TextChannel;
 import net.dv8tion.jda.api.entities.User;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.serializer.plain.PlainComponentSerializer;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 
@@ -100,6 +102,10 @@ public class Discord extends Feature {
 			message = message.replaceAll("_", "\\\\_");
 		}
 		return message;
+	}
+
+	public static String discordize(Component message) {
+		return discordize(PlainComponentSerializer.plain().serialize(message));
 	}
 
 	public static Guild getGuild() {

--- a/src/main/java/me/pugabyte/nexus/framework/commands/models/CustomCommand.java
+++ b/src/main/java/me/pugabyte/nexus/framework/commands/models/CustomCommand.java
@@ -38,6 +38,7 @@ import me.pugabyte.nexus.utils.RandomUtils;
 import me.pugabyte.nexus.utils.StringUtils;
 import me.pugabyte.nexus.utils.Tasks;
 import me.pugabyte.nexus.utils.WorldGroup;
+import net.kyori.adventure.text.Component;
 import net.md_5.bungee.api.ChatColor;
 import net.md_5.bungee.api.chat.BaseComponent;
 import org.bukkit.Bukkit;
@@ -232,6 +233,8 @@ public abstract class CustomCommand extends ICustomCommand {
 			send(sender(), (String) object);
 		else if (object instanceof JsonBuilder)
 			send(sender(), (JsonBuilder) object);
+		else if (object instanceof Component)
+			send(sender(), (Component) object);
 		else
 			throw new InvalidInputException("Cannot send object: " + object.getClass().getSimpleName());
 	}
@@ -252,12 +255,20 @@ public abstract class CustomCommand extends ICustomCommand {
 		send(sender(), builder);
 	}
 
+	protected void send(Component component) {
+		send(sender(), component);
+	}
+
 	protected void send(BaseComponent... baseComponents) {
 		send(sender(), baseComponents);
 	}
 
 	protected void send(CommandSender sender, JsonBuilder builder) {
 		builder.send(sender);
+	}
+
+	protected void send(CommandSender sender, Component component) {
+		sender.sendMessage(component);
 	}
 
 	protected void send(int delay, String message) {
@@ -994,7 +1005,7 @@ public abstract class CustomCommand extends ICustomCommand {
 		POSSESSIVE_UPPER,
 		POSSESSIVE_LOWER,
 		ACTIONARY_UPPER,
-		ACTIONARY_LOWER;
+		ACTIONARY_LOWER
 	}
 
 }

--- a/src/main/java/me/pugabyte/nexus/models/PlayerOwnedObject.java
+++ b/src/main/java/me/pugabyte/nexus/models/PlayerOwnedObject.java
@@ -5,6 +5,7 @@ import me.pugabyte.nexus.models.nerd.Nerd;
 import me.pugabyte.nexus.utils.JsonBuilder;
 import me.pugabyte.nexus.utils.StringUtils;
 import me.pugabyte.nexus.utils.Tasks;
+import net.kyori.adventure.text.Component;
 import org.bukkit.Bukkit;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.entity.Player;
@@ -48,6 +49,11 @@ public abstract class PlayerOwnedObject {
 	public void send(JsonBuilder message) {
 		if (isOnline())
 			getPlayer().sendMessage(message.build());
+	}
+
+	public void send(Component component) {
+		if (isOnline())
+			getPlayer().sendMessage(component);
 	}
 
 	public void send(int delay, String message) {

--- a/src/main/java/me/pugabyte/nexus/models/chat/PublicChannel.java
+++ b/src/main/java/me/pugabyte/nexus/models/chat/PublicChannel.java
@@ -9,11 +9,12 @@ import me.pugabyte.nexus.features.discord.DiscordId;
 import me.pugabyte.nexus.models.mutemenu.MuteMenuUser;
 import me.pugabyte.nexus.models.nerd.Nerd;
 import me.pugabyte.nexus.models.nerd.Rank;
+import me.pugabyte.nexus.utils.AdventureUtils;
 import me.pugabyte.nexus.utils.JsonBuilder;
+import net.kyori.adventure.audience.MessageType;
+import net.kyori.adventure.identity.Identified;
+import net.kyori.adventure.identity.Identity;
 import net.kyori.adventure.text.Component;
-import net.kyori.adventure.text.serializer.gson.GsonComponentSerializer;
-import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
-import net.kyori.adventure.text.serializer.plain.PlainComponentSerializer;
 import net.md_5.bungee.api.ChatColor;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
@@ -21,6 +22,7 @@ import org.bukkit.entity.Player;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 @Data
@@ -98,25 +100,131 @@ public class PublicChannel implements Channel {
 		broadcastDiscord(component);
 	}
 
+	public void broadcast(UUID sender, Component component, MuteMenuItem muteMenuItem) {
+		broadcastIngame(sender, component, muteMenuItem);
+		broadcastDiscord(component);
+	}
+
+	public void broadcast(Identified sender, Component component, MuteMenuItem muteMenuItem) {
+		broadcastIngame(sender, component, muteMenuItem);
+		broadcastDiscord(component);
+	}
+
+	public void broadcast(Identity sender, Component component, MuteMenuItem muteMenuItem) {
+		broadcastIngame(sender, component, muteMenuItem);
+		broadcastDiscord(component);
+	}
+
+	public void broadcast(UUID sender, Component component, MessageType type) {
+		broadcastIngame(sender, component, type);
+		broadcastDiscord(component);
+	}
+
+	public void broadcast(Identified sender, Component component, MessageType type) {
+		broadcastIngame(sender, component, type);
+		broadcastDiscord(component);
+	}
+
+	public void broadcast(Identity sender, Component component, MessageType type) {
+		broadcastIngame(sender, component, type);
+		broadcastDiscord(component);
+	}
+
+	public void broadcast(UUID sender, Component component) {
+		broadcastIngame(sender, component);
+		broadcastDiscord(component);
+	}
+
+	public void broadcast(Identified sender, Component component) {
+		broadcastIngame(sender, component);
+		broadcastDiscord(component);
+	}
+
+	public void broadcast(Identity sender, Component component) {
+		broadcastIngame(sender, component);
+		broadcastDiscord(component);
+	}
+
+	public void broadcast(Component component, MessageType type) {
+		broadcastIngame(component, type);
+		broadcastDiscord(component);
+	}
+
+	public void broadcast(Identity sender, Component component, MessageType type, MuteMenuItem muteMenuItem) {
+		broadcastIngame(sender, component, type, muteMenuItem);
+		broadcastDiscord(component);
+	}
+
 	public void broadcastIngame(String message) {
 		broadcastIngame(message, null);
 	}
 
 	public void broadcastIngame(String message, MuteMenuItem muteMenuItem) {
-		// hot take incoming:
-		broadcastIngame(LegacyComponentSerializer.legacySection().deserialize(message), muteMenuItem);
+		broadcastIngame(AdventureUtils.fromLegacyText(message), muteMenuItem);
 	}
 
 	public void broadcastIngame(Component component) {
-		broadcastIngame(component, null);
+		broadcastIngame(component, (MuteMenuItem) null);
 	}
 
 	public void broadcastIngame(Component component, MuteMenuItem muteMenuItem) {
-		Bukkit.getConsoleSender().sendMessage(Chat.stripColor(component));
+		broadcastIngame(Identity.nil(), component, MessageType.SYSTEM, muteMenuItem);
+	}
+
+	public void broadcastIngame(Component component, MessageType type) {
+		broadcastIngame(Identity.nil(), component, type, null);
+	}
+
+	public void broadcastIngame(UUID sender, Component component, MessageType type, MuteMenuItem muteMenuItem) {
+		broadcastIngame(AdventureUtils.identityOf(sender), component, type, muteMenuItem);
+	}
+
+	public void broadcastIngame(Identified sender, Component component, MessageType type, MuteMenuItem muteMenuItem) {
+		broadcastIngame(sender.identity(), component, type, muteMenuItem);
+	}
+
+	public void broadcastIngame(Identity sender, Component component, MessageType type, MuteMenuItem muteMenuItem) {
+		Bukkit.getConsoleSender().sendMessage(AdventureUtils.stripColor(component));
 		Bukkit.getOnlinePlayers().stream()
 				.map(player -> (Chatter) new ChatService().get(player))
 				.filter(chatter -> chatter.hasJoined(this) && !MuteMenuUser.hasMuted(chatter.getOfflinePlayer(), muteMenuItem))
-				.forEach(chatter -> chatter.send(component));
+				.forEach(chatter -> chatter.send(sender, component, type));
+	}
+
+	public void broadcastIngame(UUID sender, Component component, MessageType type) {
+		broadcastIngame(AdventureUtils.identityOf(sender), component, type, null);
+	}
+
+	public void broadcastIngame(Identified sender, Component component, MessageType type) {
+		broadcastIngame(sender.identity(), component, type, null);
+	}
+
+	public void broadcastIngame(Identity sender, Component component, MessageType type) {
+		broadcastIngame(sender, component, type, null);
+	}
+
+	public void broadcastIngame(UUID sender, Component component) {
+		broadcastIngame(AdventureUtils.identityOf(sender), component, MessageType.SYSTEM, null);
+	}
+
+	public void broadcastIngame(Identified sender, Component component) {
+		broadcastIngame(sender.identity(), component, MessageType.SYSTEM, null);
+	}
+
+	public void broadcastIngame(Identity sender, Component component) {
+		broadcastIngame(sender, component, MessageType.SYSTEM, null);
+	}
+
+	public void broadcastIngame(UUID sender, Component component, MuteMenuItem muteMenuItem) {
+		broadcastIngame(AdventureUtils.identityOf(sender), component, MessageType.SYSTEM, muteMenuItem);
+	}
+
+	public void broadcastIngame(Identified sender, Component component, MuteMenuItem muteMenuItem) {
+		broadcastIngame(sender.identity(), component, MessageType.SYSTEM, muteMenuItem);
+	}
+
+	public void broadcastIngame(Identity sender, Component component, MuteMenuItem muteMenuItem) {
+		broadcastIngame(sender, component, MessageType.SYSTEM, muteMenuItem);
 	}
 
 	public void broadcastDiscord(String message) {
@@ -125,7 +233,7 @@ public class PublicChannel implements Channel {
 	}
 
 	public void broadcastDiscord(Component component) {
-		broadcastDiscord(PlainComponentSerializer.plain().serialize(component));
+		broadcastDiscord(AdventureUtils.asPlainText(component));
 	}
 
 	public void broadcast(JsonBuilder builder) {
@@ -143,7 +251,7 @@ public class PublicChannel implements Channel {
 	}
 
 	public void broadcastIngame(JsonBuilder builder, MuteMenuItem muteMenuItem) {
-		broadcastIngame(GsonComponentSerializer.gson().deserialize(builder.serialize()), muteMenuItem);
+		broadcastIngame(AdventureUtils.fromJson(builder), muteMenuItem);
 	}
 
 	public void broadcastIngame(Chatter chatter, JsonBuilder builder) {

--- a/src/main/java/me/pugabyte/nexus/models/chat/PublicChannel.java
+++ b/src/main/java/me/pugabyte/nexus/models/chat/PublicChannel.java
@@ -25,6 +25,8 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
+import static me.pugabyte.nexus.utils.StringUtils.colorize;
+
 @Data
 @Builder
 public class PublicChannel implements Channel {
@@ -160,7 +162,7 @@ public class PublicChannel implements Channel {
 	}
 
 	public void broadcastIngame(String message, MuteMenuItem muteMenuItem) {
-		broadcastIngame(AdventureUtils.fromLegacyText(message), muteMenuItem);
+		broadcastIngame(AdventureUtils.fromLegacyText(colorize(message)), muteMenuItem);
 	}
 
 	public void broadcastIngame(Component component) {

--- a/src/main/java/me/pugabyte/nexus/utils/AdventureUtils.java
+++ b/src/main/java/me/pugabyte/nexus/utils/AdventureUtils.java
@@ -1,0 +1,63 @@
+package me.pugabyte.nexus.utils;
+
+import net.kyori.adventure.identity.Identified;
+import net.kyori.adventure.identity.Identity;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.TranslatableComponent;
+import net.kyori.adventure.text.format.Style;
+import net.kyori.adventure.text.serializer.gson.GsonComponentSerializer;
+import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
+import net.kyori.adventure.text.serializer.plain.PlainComponentSerializer;
+import org.bukkit.OfflinePlayer;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+public class AdventureUtils {
+	public static Component stripColor(Component component) {
+		component = component.style(Style.empty());
+		if (component instanceof TranslatableComponent) {
+			TranslatableComponent tComponent = (TranslatableComponent) component;
+			component = tComponent.args(stripColor(tComponent.args()));
+		}
+		return component.children(stripColor(component.children()));
+	}
+
+	public static List<Component> stripColor(Collection<Component> components) {
+		return components.stream().map(AdventureUtils::stripColor).collect(Collectors.toList());
+	}
+
+	public static String asPlainText(Component component) {
+		return PlainComponentSerializer.plain().serialize(component);
+	}
+
+	public static String asLegacyText(Component component) {
+		return LegacyComponentSerializer.legacySection().serialize(component);
+	}
+
+	public static Component fromLegacyText(String string) {
+		return LegacyComponentSerializer.legacySection().deserialize(string);
+	}
+
+	public static Component fromLegacyAmpersandText(String string) {
+		return LegacyComponentSerializer.legacyAmpersand().deserialize(string);
+	}
+
+	public static Component fromJson(JsonBuilder json) {
+		return GsonComponentSerializer.gson().deserialize(json.serialize());
+	}
+
+	public static Identity identityOf(Identified object) {
+		return object.identity();
+	}
+
+	public static Identity identityOf(UUID uuid) {
+		return Identity.identity(uuid);
+	}
+
+	public static Identity identityOf(OfflinePlayer player) {
+		return identityOf(player.getUniqueId());
+	}
+}

--- a/src/main/java/me/pugabyte/nexus/utils/PlayerUtils.java
+++ b/src/main/java/me/pugabyte/nexus/utils/PlayerUtils.java
@@ -17,6 +17,7 @@ import me.pugabyte.nexus.models.nerd.Nerd;
 import me.pugabyte.nexus.models.nerd.NerdService;
 import me.pugabyte.nexus.utils.Utils.MinMaxResult;
 import net.dv8tion.jda.annotations.ReplaceWith;
+import net.kyori.adventure.text.Component;
 import net.md_5.bungee.api.chat.BaseComponent;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
@@ -243,6 +244,10 @@ public class PlayerUtils {
 
 	public static void send(CommandSender sender, BaseComponent... baseComponents) {
 		sender.sendMessage(baseComponents);
+	}
+
+	public static void send(CommandSender sender, Component component) {
+		sender.sendMessage(component);
 	}
 
 	public static boolean hasRoomFor(Player player, ItemStack... items) {


### PR DESCRIPTION
Potential breaking changes: various chat messages are now being serialized to Adventure Components to support setting the sender of a message and the type of message
- https://github.com/Pugabyte/Nexus/blob/feature/adventure/src/main/java/me/pugabyte/nexus/models/chat/PublicChannel.java#L163
- https://github.com/Pugabyte/Nexus/blob/feature/adventure/src/main/java/me/pugabyte/nexus/models/chat/PublicChannel.java#L254
- https://github.com/Pugabyte/Nexus/blob/feature/adventure/src/main/java/me/pugabyte/nexus/features/chat/ChatManager.java#L129-L130
- https://github.com/Pugabyte/Nexus/blob/feature/adventure/src/main/java/me/pugabyte/nexus/features/chat/ChatManager.java#L149

they're using methods from Adventure themselves to serialize so they should work 100% and my testing has all worked very well

this closes Pugabyte/BearNation#560 and opens the door to work on Pugabyte/BearNation#35. as a bonus, death message data like weapons hover are now preserved and player names are replaced with nicknames.